### PR TITLE
STOMP 환경 설정 및 socket 예외 핸들러 구현

### DIFF
--- a/src/main/kotlin/com/gsmNetworking/chat/common/error/exception/StompException.kt
+++ b/src/main/kotlin/com/gsmNetworking/chat/common/error/exception/StompException.kt
@@ -1,0 +1,12 @@
+package com.gsmNetworking.chat.common.error.exception
+
+import com.gsmNetworking.chat.common.error.model.ErrorCode
+
+/**
+ * GSM Networking 프로젝트에서 사용하는 Exception,
+ * STOMP 통신 중인 사용자에게 예외 상황을 알리기 위해 사용합니다.
+ */
+open class StompException(
+    val code: ErrorCode = ErrorCode.DEFAULT,
+    override val message: String
+): RuntimeException(message)

--- a/src/main/kotlin/com/gsmNetworking/chat/common/socket/dto/StompErrorMessage.kt
+++ b/src/main/kotlin/com/gsmNetworking/chat/common/socket/dto/StompErrorMessage.kt
@@ -1,0 +1,11 @@
+package com.gsmNetworking.chat.common.socket.dto
+
+import com.gsmNetworking.chat.common.error.model.ErrorCode
+
+/**
+ * Exception 정보를 STOMP 메시지로 전달하기 위한 객체입니다.
+ */
+class StompErrorMessage(
+    val errorCode: ErrorCode = ErrorCode.DEFAULT,
+    val message: String
+)

--- a/src/main/kotlin/com/gsmNetworking/chat/common/socket/dto/StompMessage.kt
+++ b/src/main/kotlin/com/gsmNetworking/chat/common/socket/dto/StompMessage.kt
@@ -1,0 +1,8 @@
+package com.gsmNetworking.chat.common.socket.dto
+
+/**
+ * STOMP 메시지를 사용자에게 전달하기 위한 Wrapper 객체입니다.
+ */
+class StompMessage<T>(
+    val content: T
+)

--- a/src/main/kotlin/com/gsmNetworking/chat/common/socket/processor/StompErrorProcessor.kt
+++ b/src/main/kotlin/com/gsmNetworking/chat/common/socket/processor/StompErrorProcessor.kt
@@ -1,0 +1,37 @@
+package com.gsmNetworking.chat.common.socket.processor
+
+import com.gsmNetworking.chat.common.error.exception.StompException
+import com.gsmNetworking.chat.common.socket.sender.StompErrorSender
+import com.gsmNetworking.chat.common.socket.dto.StompErrorMessage
+import org.springframework.stereotype.Component
+
+/**
+ * STOMP 에러 처리를 적절한 Sender에게 위임합니다.
+ * @see StompErrorSender
+ */
+@Component
+class StompErrorProcessor(
+    private val senders: List<StompErrorSender>
+) {
+
+    init {
+        require(senders.isNotEmpty()) { "하나 이상의 StompErrorSender를 등록해야 합니다" }
+    }
+
+    /**
+     * 처리 가능한 Sender에게 STOMP 에러 처리를 위임합니다.
+     * @param ex [StompException] 또는 [StompException]의 자식;
+     * @see StompErrorSender
+     */
+    fun sendError(ex: StompException) {
+        val supportedSenders = senders.filter { it.supports(ex.javaClass) }
+
+        if (supportedSenders.isEmpty()) {
+            throw IllegalStateException("지원하는 senders가 존재하지 않습니다 : ${ex.javaClass}")
+        }
+
+        supportedSenders.forEach { sender ->
+            sender.send(StompErrorMessage(ex.code, ex.message))
+        }
+    }
+}

--- a/src/main/kotlin/com/gsmNetworking/chat/common/socket/processor/StompErrorProcessor.kt
+++ b/src/main/kotlin/com/gsmNetworking/chat/common/socket/processor/StompErrorProcessor.kt
@@ -15,7 +15,9 @@ class StompErrorProcessor(
 ) {
 
     init {
-        require(senders.isNotEmpty()) { "하나 이상의 StompErrorSender를 등록해야 합니다" }
+        require(senders.isNotEmpty()) {
+            "하나 이상의 StompErrorSender를 등록해야 합니다"
+        }
     }
 
     /**
@@ -27,7 +29,7 @@ class StompErrorProcessor(
         val supportedSenders = senders.filter { it.supports(ex.javaClass) }
 
         if (supportedSenders.isEmpty()) {
-            throw IllegalStateException("지원하는 senders가 존재하지 않습니다 : ${ex.javaClass}")
+            throw IllegalStateException("${ex.javaClass}를 처리를 지원하는 senders가 존재하지 않습니다")
         }
 
         supportedSenders.forEach { sender ->

--- a/src/main/kotlin/com/gsmNetworking/chat/common/socket/sender/StompErrorSender.kt
+++ b/src/main/kotlin/com/gsmNetworking/chat/common/socket/sender/StompErrorSender.kt
@@ -1,0 +1,25 @@
+package com.gsmNetworking.chat.common.socket.sender
+
+import com.gsmNetworking.chat.common.error.exception.StompException
+import com.gsmNetworking.chat.common.socket.dto.StompErrorMessage
+
+/**
+ * Stomp 에러 메시지를 전송하는 역할의 객체입니다.
+ */
+interface StompErrorSender {
+    /**
+     * Stomp 에러 메시지를 전송합니다.
+     *
+     * @param message 전송할 에러 메시지
+     */
+    fun send(message: StompErrorMessage)
+
+    /**
+     * 특정 Exception Class 지원 여부를 확인합니다.
+     *
+     * @param clazz 지원 여부를 확인할 [StompException] 또는 [StompException]의 자식 클래스
+     * @return 지원한다면 True, 지원하지 않으면 False를 반환
+     * @see StompException
+     */
+    fun supports(clazz: Class<out StompException>): Boolean
+}

--- a/src/main/kotlin/com/gsmNetworking/chat/domain/chat/exception/ChatStompException.kt
+++ b/src/main/kotlin/com/gsmNetworking/chat/domain/chat/exception/ChatStompException.kt
@@ -1,0 +1,16 @@
+package com.gsmNetworking.chat.domain.chat.exception
+
+import com.gsmNetworking.chat.common.error.exception.StompException
+import com.gsmNetworking.chat.common.error.model.ErrorCode
+
+/**
+ * [StompException]의 구현체, Chat 도메인에서 발생한 예외에 대한 설명을 Client에게 전달하기 위해 사용합니다.
+ *
+ * @param code
+ * @param message
+ */
+class ChatStompException(
+    code: ErrorCode = ErrorCode.DEFAULT,
+    message: String
+) : StompException(code, message) {
+}

--- a/src/main/kotlin/com/gsmNetworking/chat/domain/chat/sender/CharErrorSender.kt
+++ b/src/main/kotlin/com/gsmNetworking/chat/domain/chat/sender/CharErrorSender.kt
@@ -1,0 +1,32 @@
+package com.gsmNetworking.chat.domain.chat.sender
+
+import com.gsmNetworking.chat.common.error.exception.StompException
+import com.gsmNetworking.chat.common.socket.dto.StompErrorMessage
+import com.gsmNetworking.chat.common.socket.sender.StompErrorSender
+import com.gsmNetworking.chat.domain.chat.exception.ChatStompException
+import org.springframework.stereotype.Component
+
+/**
+ * [StompErrorSender]의 구현체, Char 도메인의 Stomp 에러 메시지를 처리합니다.
+ */
+@Component
+class CharErrorSender : StompErrorSender {
+    /**
+     * Stomp 에러 메시지를 전송하는 메서드입니다.
+     *
+     * @param message 전송할 에러 메시지
+     */
+    override fun send(message: StompErrorMessage) {
+        TODO("Not yet implemented")
+    }
+
+    /**
+     * 특정 [StompException] Class 또는 해당 클래스의 하위 클래스를 지원하는지 확인합니다.
+     *
+     * @param clazz 지원 여부를 확인할 [StompException] 또는 [StompException]의 자식 클래스
+     * @return 지원한다면 True, 지원하지 않으면 False를 반환
+     */
+    override fun supports(clazz: Class<out StompException>): Boolean {
+        return ChatStompException::class.java.isAssignableFrom(clazz)
+    }
+}

--- a/src/main/kotlin/com/gsmNetworking/chat/domain/room/exception/RoomStompException.kt
+++ b/src/main/kotlin/com/gsmNetworking/chat/domain/room/exception/RoomStompException.kt
@@ -1,0 +1,16 @@
+package com.gsmNetworking.chat.domain.room.exception
+
+import com.gsmNetworking.chat.common.error.exception.StompException
+import com.gsmNetworking.chat.common.error.model.ErrorCode
+
+/**
+ * [StompException]의 구현체, Room 도메인에서 발생한 예외에 대한 설명을 Client에게 전달하기 위해 사용합니다.
+ *
+ * @param code
+ * @param message
+ */
+class RoomStompException(
+    code: ErrorCode = ErrorCode.DEFAULT,
+    message: String
+) : StompException(code, message) {
+}

--- a/src/main/kotlin/com/gsmNetworking/chat/domain/room/sender/RoomErrorSender.kt
+++ b/src/main/kotlin/com/gsmNetworking/chat/domain/room/sender/RoomErrorSender.kt
@@ -1,0 +1,32 @@
+package com.gsmNetworking.chat.domain.room.sender
+
+import com.gsmNetworking.chat.common.error.exception.StompException
+import com.gsmNetworking.chat.common.socket.dto.StompErrorMessage
+import com.gsmNetworking.chat.common.socket.sender.StompErrorSender
+import com.gsmNetworking.chat.domain.room.exception.RoomStompException
+import org.springframework.stereotype.Component
+
+/**
+ * [StompErrorSender]의 구현체, Room 도메인의 Stomp 에러 메시지를 처리합니다.
+ */
+@Component
+class RoomErrorSender : StompErrorSender {
+    /**
+     * Stomp 에러 메시지를 전송하는 메서드입니다.
+     *
+     * @param message 전송할 에러 메시지
+     */
+    override fun send(message: StompErrorMessage) {
+        TODO("Not yet implemented")
+    }
+
+    /**
+     * 특정 [StompException] Class 또는 해당 클래스의 하위 클래스를 지원하는지 확인합니다.
+     *
+     * @param clazz 지원 여부를 확인할 [StompException] 또는 [StompException]의 자식 클래스
+     * @return 지원한다면 True, 지원하지 않으면 False를 반환
+     */
+    override fun supports(clazz: Class<out StompException>): Boolean {
+        return RoomStompException::class.java.isAssignableFrom(clazz)
+    }
+}

--- a/src/main/kotlin/com/gsmNetworking/chat/domain/user/exception/UserStompException.kt
+++ b/src/main/kotlin/com/gsmNetworking/chat/domain/user/exception/UserStompException.kt
@@ -1,0 +1,16 @@
+package com.gsmNetworking.chat.domain.user.exception
+
+import com.gsmNetworking.chat.common.error.exception.StompException
+import com.gsmNetworking.chat.common.error.model.ErrorCode
+
+/**
+ * [StompException]의 구현체, User 도메인에서 발생한 예외에 대한 설명을 Client에게 전달하기 위해 사용합니다.
+ *
+ * @param code
+ * @param message
+ */
+class UserStompException(
+    code: ErrorCode = ErrorCode.DEFAULT,
+    message: String
+) : StompException(code, message) {
+}

--- a/src/main/kotlin/com/gsmNetworking/chat/domain/user/sender/UserErrorSender.kt
+++ b/src/main/kotlin/com/gsmNetworking/chat/domain/user/sender/UserErrorSender.kt
@@ -1,0 +1,32 @@
+package com.gsmNetworking.chat.domain.user.sender
+
+import com.gsmNetworking.chat.common.error.exception.StompException
+import com.gsmNetworking.chat.common.socket.dto.StompErrorMessage
+import com.gsmNetworking.chat.common.socket.sender.StompErrorSender
+import com.gsmNetworking.chat.domain.user.exception.UserStompException
+import org.springframework.stereotype.Component
+
+/**
+ * [StompErrorSender]의 구현체, User 도메인의 Stomp 에러 메시지를 처리합니다.
+ */
+@Component
+class UserErrorSender : StompErrorSender {
+    /**
+     * Stomp 에러 메시지를 전송하는 메서드입니다.
+     *
+     * @param message 전송할 에러 메시지
+     */
+    override fun send(message: StompErrorMessage) {
+        TODO("Not yet implemented")
+    }
+
+    /**
+     * 특정 [StompException] Class 또는 해당 클래스의 하위 클래스를 지원하는지 확인합니다.
+     *
+     * @param clazz 지원 여부를 확인할 [StompException] 또는 [StompException]의 자식 클래스
+     * @return 지원한다면 True, 지원하지 않으면 False를 반환
+     */
+    override fun supports(clazz: Class<out StompException>): Boolean {
+        return UserStompException::class.java.isAssignableFrom(clazz)
+    }
+}

--- a/src/main/kotlin/com/gsmNetworking/chat/global/exception/handler/GlobalSocketExceptionHandler.kt
+++ b/src/main/kotlin/com/gsmNetworking/chat/global/exception/handler/GlobalSocketExceptionHandler.kt
@@ -1,0 +1,34 @@
+package com.gsmNetworking.chat.global.exception.handler
+
+import com.gsmNetworking.chat.common.error.exception.StompException
+import com.gsmNetworking.chat.common.socket.processor.StompErrorProcessor
+import org.slf4j.LoggerFactory
+import org.springframework.messaging.Message
+import org.springframework.stereotype.Component
+import org.springframework.web.socket.messaging.StompSubProtocolErrorHandler
+
+
+/**
+ * Socket 통신 중에 발생하는 에러를 전역적으로 관리하는 handler 입니다.
+ */
+@Component
+class GlobalSocketExceptionHandler(
+    private val stompErrorProcessor: StompErrorProcessor
+) : StompSubProtocolErrorHandler() {
+    private val log = LoggerFactory.getLogger(this.javaClass)!! //TODO 로깅 구현 통일하기
+    override fun handleClientMessageProcessingError(
+        clientMessage: Message<ByteArray>?,
+        ex: Throwable
+    ): Message<ByteArray>? {
+        when (val cause = ex.cause) {
+            is StompException -> {
+                stompErrorProcessor.sendError(cause)
+            }
+            is Exception -> {
+                log.error("An error occurred", ex)
+            }
+        }
+
+        return super.handleClientMessageProcessingError(clientMessage, ex)
+    }
+}

--- a/src/main/kotlin/com/gsmNetworking/chat/global/socket/config/StompWebSocketConfig.kt
+++ b/src/main/kotlin/com/gsmNetworking/chat/global/socket/config/StompWebSocketConfig.kt
@@ -1,0 +1,22 @@
+package com.gsmNetworking.chat.global.socket.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.messaging.simp.config.MessageBrokerRegistry
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer
+
+@Configuration
+@EnableWebSocketMessageBroker
+class StompWebSocketConfig : WebSocketMessageBrokerConfigurer {
+
+    override fun configureMessageBroker(config: MessageBrokerRegistry) {
+        config.enableSimpleBroker("/sub", "/user")
+        config.setApplicationDestinationPrefixes("/pub")
+    }
+
+    override fun registerStompEndpoints(registry: StompEndpointRegistry) {
+        registry.addEndpoint("/ws")
+            .setAllowedOriginPatterns("*")
+    }
+}


### PR DESCRIPTION
## 개요.
STOMP 환경 설정을 추가하였습니다.
또한, Socket Exception Handler와 Socket 통신 중 예외 발생 시 사용자에게 예외를 전달하는 기능을 추가하였습니다.

## 본문 
### STOMP 환경 설정
- `StompWebSocketConfig` : STOMP를 사용하기위한 config 객체
- `StompMessage`
  - STOMP 통신 시 사용할 Wrapper 객체
  - Sender를 사용해 통신 시 DTO를 사용하게 됩니다, 타입 지정이 필요하면 시 Any 타입으로 지정해야 하는데, 안전성이나 유지보수 면에서 좋지 않다고 생각해 해당 클래스를 사용하도록 하였습니다.
  
### Socket 예외처리
- `GlobalSocketExceptionHandler` : 전역으로 Socket 예외를 처리하는 Handler
- `StompErrorProcessor` : StompError를 사용자에게 전달하는 객체, `StompErrorSender` 에게 처리를 위임합니다.
- `StompErrorSender` 
  - StompError를 사용자에게 전달하는 역할의 인터페이스
  - 인터페이스를 사용한 이유는 상황에 따라 다른 websocket에 응답을 보내야 하기 때문입니다.
  - global과 domain 사이의 의존성이 없도록 각 도메인에서 `StompErrorSender`를 구현하도록 하였습니다.
- `StompException` : Client에게 예외 상황을 전달하기 위해 사용하는 Exception

#### Room 도메인 예외처리
- `RoomStompException` : Room 관련 에러 혹은 Room WebSocket에 예외상황을 전달하기 위해 사용되는 에러
- `RoomStompErrorSender` : `RoomStompException`를 처리하는 `StompErrorSender` 구현체
#### Chat 도메인 예외처리
객체 설명은 위와 동일하므로 생략하도록 하겠습니다.
- `ChatStompException`
- `ChatStompErrorSender` 
#### User 도메인 예외처리
- `UserStompException`
- `UserStompErrorSender` 